### PR TITLE
Update cursor position on reflow

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import * as vscode from "vscode";
 
 export function activate(context: vscode.ExtensionContext) {
 
-    let disposable = vscode.commands.registerCommand("extension.reflowParagraph", () => {
+    let disposable = vscode.commands.registerCommand("extension.reflowParagraph", async () => {
 
         let editor = vscode.window.activeTextEditor;
         if (!editor) {
@@ -87,14 +87,14 @@ export function activate(context: vscode.ExtensionContext) {
         // textEditorEdit.replace will insert the correct environment-specific line-endings 
         let newParagraph = newLines.join("\n");
 
-        let applied = editor.edit(
+        let applied = await editor.edit(
             function (textEditorEdit) {
                 textEditorEdit.replace(range, newParagraph);
             }
         );
 
-        // reset selection (TODO may be contraintuitive... maybe rather reset to single position, always?)
-        editor.selection = selection;
+        const lastReplacedLine = editor.document.lineAt(range.start.line + newLines.length - 1);
+        editor.selection = new vscode.Selection(lastReplacedLine.range.end, lastReplacedLine.range.end);
     });
 
     context.subscriptions.push(disposable);

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -19,4 +19,20 @@ suite("Extension Tests", () => {
         assert.equal(-1, [1, 2, 3].indexOf(5));
         assert.equal(-1, [1, 2, 3].indexOf(0));
     });
+
+    test("Set cursor to end of selection", async () => {
+        const document = vscode.Uri.parse('untitled:summary.txt');
+        const doc = await vscode.workspace.openTextDocument(document);
+        const editor = await vscode.window.showTextDocument(doc, 1, false);
+        const firstLine = editor.document.lineAt(0);
+        const lastLine = editor.document.lineAt(editor.document.lineCount - 1);
+        const textRange = new vscode.Range(0, firstLine.range.start.character, editor.document.lineCount - 1, lastLine.range.end.character);
+        await editor.edit(e => e.replace(textRange, "This is a very long line of text that needs to be reflowed into multiple lines at interesting points"));
+        const cursorPosition = new vscode.Position(0, 98);
+        editor.selection.with(cursorPosition, cursorPosition);
+        const context : any = { "subscriptions": [] };
+        const v = await vscode.commands.executeCommand("extension.reflowParagraph");
+        assert.equal(editor.selection.active.line, 1);
+        assert.equal(editor.selection.active.character, 21);
+    })
 });


### PR DESCRIPTION
To stay in line with how vim handles reflow, update the active cursor position to the end of the reflowed text upon completion.